### PR TITLE
change MoveDataAccessInterface and MoveOutPutBoundary from class to i…

### DIFF
--- a/src/main/java/app/ChessAppBuilder.java
+++ b/src/main/java/app/ChessAppBuilder.java
@@ -1,4 +1,76 @@
 package app;
 
+import javax.swing.JFrame;
+import javax.swing.WindowConstants;
+
+import data_access.ChessDataAccessObject;
+import interface_adapter.ViewManagerModel;
+import interface_adapter.move.MoveController;
+import interface_adapter.move.MovePresenter;
+import interface_adapter.move.MoveViewModel;
+import use_case.move.MoveInteractor;
+import use_case.move.MoveOutPutBoundary;
+import view.ChessBoardView;
+
+/**
+ * Builder for the Note Application.
+ */
 public class ChessAppBuilder {
+    public static final int HEIGHT = 800;
+    public static final int WIDTH = 800;
+    // TODO change to ChessDataAccessInterface once implemented
+    private ChessDataAccessObject chessDataAccessObject;
+    private MoveViewModel moveViewModel = new MoveViewModel();
+    private final ViewManagerModel viewManagerModel = new ViewManagerModel();
+    private ChessBoardView chessBoardView;
+    private MoveInteractor moveInteractor;
+
+    /**
+     * Set the ChessDAO to be used in this application.
+     * @param chessDataAccess the DAO to use
+     * @return this builder
+     */
+    public ChessAppBuilder addChessDAO(ChessDataAccessObject chessDataAccess) {
+        chessDataAccessObject = chessDataAccess;
+        return this;
+    }
+
+    /**
+     * Creates the objects for the Move Use Case and connects the ChessBoardView to Move controller.
+     * @return this builder
+     */
+    public ChessAppBuilder addMoveUseCase() {
+        final MoveOutPutBoundary moveOutPutBoundary = new MovePresenter(moveViewModel, viewManagerModel);
+        moveInteractor = new MoveInteractor(
+                chessDataAccessObject, moveOutPutBoundary);
+
+        final MoveController moveController = new MoveController(moveInteractor);
+        chessBoardView.setMoveController(moveController);
+        return this;
+    }
+
+    /**
+     * Creates the ChessBoardView and underlying MoveViewModel.
+     * @return this builder
+     */
+    public ChessAppBuilder addMoveView() {
+        moveViewModel = new MoveViewModel();
+        final MoveController moveController = new MoveController(moveInteractor);
+        chessBoardView = new ChessBoardView(moveViewModel, moveController);
+        return this;
+    }
+
+    /**
+     * Builds the app.
+     * @return the JFrame for the app
+     */
+    public JFrame build() {
+        final JFrame frame = new JFrame();
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        frame.setTitle("Chess App");
+        frame.setSize(WIDTH, HEIGHT);
+
+        frame.add(chessBoardView);
+        return frame;
+    }
 }

--- a/src/main/java/app/MainChessApp.java
+++ b/src/main/java/app/MainChessApp.java
@@ -1,11 +1,25 @@
 package app;
 
 import data_access.ChessDataAccessObject;
-import use_case.note.NoteDataAccessInterface;
 
+/**
+ * This is the main chess app.
+ */
 public class MainChessApp {
 
+    /**
+     * Main method.
+     * @param args commandline arguments
+     */
     public static void main(String[] args) {
+
+        // TODO change to ChessDataAccessInterface once implemented
+        final ChessDataAccessObject chessDataAccessObject = new ChessDataAccessObject();
+
+        final ChessAppBuilder chessAppBuilder = new ChessAppBuilder();
+        chessAppBuilder.addChessDAO(chessDataAccessObject)
+                .addMoveView()
+                .addMoveUseCase().build().setVisible(true);
 
     }
 }

--- a/src/main/java/data_access/ChessDataAccessObject.java
+++ b/src/main/java/data_access/ChessDataAccessObject.java
@@ -1,4 +1,11 @@
 package data_access;
 
-public class ChessDataAccessObject {
+import use_case.daily_puzzle.DailyPuzzleDataAccessInterface;
+import use_case.move.MoveDataAccessInterface;
+
+/**
+ * The DAO to access lichess API.
+ * related use case are 'daily Puzzle' & 'Move'
+ */
+public class ChessDataAccessObject implements MoveDataAccessInterface, DailyPuzzleDataAccessInterface {
 }

--- a/src/main/java/entity/ChessPiece.java
+++ b/src/main/java/entity/ChessPiece.java
@@ -2,6 +2,9 @@ package entity;
 
 import java.util.ArrayList;
 
+/**
+ * The abstract class of all chess piece.
+ */
 public abstract class ChessPiece {
     private String color;
     private ArrayList<Integer> position;

--- a/src/main/java/interface_adapter/move/MoveController.java
+++ b/src/main/java/interface_adapter/move/MoveController.java
@@ -25,6 +25,6 @@ public class MoveController {
         position.add(xcord);
         position.add(ycord);
         final MoveInputdata moveInputdata = new MoveInputdata(position);
-        moveInteractor.handleClick(moveInputdata);
+        moveInteractor.execute(moveInputdata);
     }
 }

--- a/src/main/java/interface_adapter/move/MovePresenter.java
+++ b/src/main/java/interface_adapter/move/MovePresenter.java
@@ -1,4 +1,17 @@
 package interface_adapter.move;
 
-public class MovePresenter {
+import interface_adapter.ViewManagerModel;
+import use_case.move.MoveOutPutBoundary;
+
+/**
+ * The presenter for Move use case.
+ */
+public class MovePresenter implements MoveOutPutBoundary {
+    private final MoveViewModel moveViewModel;
+    private final ViewManagerModel viewManagerModel;
+
+    public MovePresenter(MoveViewModel moveViewModel, ViewManagerModel viewManagerModel) {
+        this.moveViewModel = moveViewModel;
+        this.viewManagerModel = viewManagerModel;
+    }
 }

--- a/src/main/java/use_case/daily_puzzle/DailyPuzzleDataAccessInterface.java
+++ b/src/main/java/use_case/daily_puzzle/DailyPuzzleDataAccessInterface.java
@@ -1,4 +1,7 @@
 package use_case.daily_puzzle;
 
-public class DailyPuzzleDataAccessInterface {
+/**
+ * DAO for Daily Puzzle use case.
+ */
+public interface DailyPuzzleDataAccessInterface {
 }

--- a/src/main/java/use_case/move/MoveDataAccessInterface.java
+++ b/src/main/java/use_case/move/MoveDataAccessInterface.java
@@ -1,0 +1,4 @@
+package use_case.move;
+
+public interface MoveDataAccessInterface {
+}

--- a/src/main/java/use_case/move/MoveDataAccessinterface.java
+++ b/src/main/java/use_case/move/MoveDataAccessinterface.java
@@ -1,4 +1,0 @@
-package use_case.move;
-
-public class MoveDataAccessinterface {
-}

--- a/src/main/java/use_case/move/MoveInputBoundary.java
+++ b/src/main/java/use_case/move/MoveInputBoundary.java
@@ -8,5 +8,5 @@ public interface MoveInputBoundary {
      * Executes the move use case.
      * @param moveInputData the input data
      */
-    void handleClick(MoveInputdata moveInputData);
+    void execute(MoveInputdata moveInputData);
 }

--- a/src/main/java/use_case/move/MoveInteractor.java
+++ b/src/main/java/use_case/move/MoveInteractor.java
@@ -1,21 +1,25 @@
 package use_case.move;
 
+import entity.Game;
 /**
  * Move interactor who handles the business logic of move.
  */
 public class MoveInteractor implements MoveInputBoundary {
-    private entity.Game game;
+    private final MoveDataAccessInterface moveDataAccessObject;
+    private final MoveOutPutBoundary moveOutPutBoundary;
 
-    public MoveInteractor(entity.Game game) {
-        this.game = game;
+    public MoveInteractor(MoveDataAccessInterface moveDataAccessObject,
+                          MoveOutPutBoundary moveOutPutBoundary) {
+        this.moveDataAccessObject = moveDataAccessObject;
+        this.moveOutPutBoundary = moveOutPutBoundary;
     }
 
-    public boolean isvalidmove() {
-        // check if this move is valid
-    }
+//    private boolean isvalidmove() {
+//        // check if this move is valid
+//    }
 
     @Override
-    public void handleClick(MoveInputdata position) {
+    public void execute(MoveInputdata position) {
         // Starting point of this class
 
     }

--- a/src/main/java/use_case/move/MoveOutPutBoundary.java
+++ b/src/main/java/use_case/move/MoveOutPutBoundary.java
@@ -1,0 +1,4 @@
+package use_case.move;
+
+public interface MoveOutPutBoundary {
+}

--- a/src/main/java/use_case/move/MoveOutputPort.java
+++ b/src/main/java/use_case/move/MoveOutputPort.java
@@ -1,4 +1,0 @@
-package use_case.move;
-
-public class MoveOutputPort {
-}

--- a/src/main/java/view/ChessBoardView.java
+++ b/src/main/java/view/ChessBoardView.java
@@ -18,7 +18,7 @@ public class ChessBoardView extends JPanel implements ActionListener, PropertyCh
 
     private final String viewName = "Chess Board";
     private final MoveViewModel moveViewModel;
-    private final MoveController moveController;
+    private MoveController moveController;
 
     public ChessBoardView(MoveViewModel moveViewModel, MoveController moveController) {
         this.moveViewModel = moveViewModel;
@@ -56,6 +56,10 @@ public class ChessBoardView extends JPanel implements ActionListener, PropertyCh
             }
         }
 
+    }
+
+    public void setMoveController(MoveController moveController) {
+        this.moveController = moveController;
     }
 
     @Override

--- a/src/test/java/view/ChessBoardViewTest.java
+++ b/src/test/java/view/ChessBoardViewTest.java
@@ -1,10 +1,17 @@
 package view;
 
+import data_access.ChessDataAccessObject;
+import entity.Board;
+import entity.Game;
+import interface_adapter.ViewManagerModel;
 import interface_adapter.move.MoveController;
+import interface_adapter.move.MovePresenter;
 import interface_adapter.move.MoveViewModel;
+import use_case.move.MoveDataAccessInterface;
+import use_case.move.MoveInteractor;
+import use_case.move.MoveOutPutBoundary;
 
 import javax.swing.*;
-import java.awt.*;
 
 
 public class ChessBoardViewTest {
@@ -15,7 +22,12 @@ public class ChessBoardViewTest {
         frame.setSize(800, 800);
 
         MoveViewModel TestModel = new MoveViewModel();
-        MoveController TestController = new MoveController();
+        MoveDataAccessInterface moveDataAccessObject = new ChessDataAccessObject();
+        MoveViewModel moveViewModel = new MoveViewModel();
+        ViewManagerModel viewManagerModel = new ViewManagerModel();
+        MoveOutPutBoundary movePresenter = new MovePresenter(moveViewModel, viewManagerModel);
+        MoveInteractor TestInteractor = new MoveInteractor(moveDataAccessObject, movePresenter);
+        MoveController TestController = new MoveController(TestInteractor);
 
         ChessBoardView TestView = new ChessBoardView(TestModel, TestController);
 


### PR DESCRIPTION
1: change MoveDataAccessInterface and MoveOutPutBoundary from class to interface by delete and recreate
2: 'DailPuzzleDataAccessInterface.java' & 'ChessDataAccessObject.java' & created
3: Excute method of 'MoveInputBoundary.java' & 'MoveInteractor.java' rename to 'excute'.
4: Minimal 'MovePresenter.java' implemented (without logic).
5: IMPORTANT!!: 'Game' instancevariable deleted from 'MoveInteractor.java' (need further discussion, because i think it's not 'MoveInteractor's job to initiate a 'game').
6: 'MainChessApp.java' and associate 'ChessAppBuilder.java' implemented, Default chessboard view can now be seen by running 'MainChessApp.java'
7: Some CheckStyle cleanup
